### PR TITLE
Fix stale update lock error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acuris/leprechaun-cache",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "private": false,
   "description": "Caching library that supports double checked caching and stale returns to avoid stampede and slow responses",
   "keywords": [

--- a/src/leprechaun-cache.ts
+++ b/src/leprechaun-cache.ts
@@ -90,8 +90,12 @@ export class LeprechaunCache<T extends Cacheable = Cacheable> {
     }
 
     const update = this.updateCache(key, ttl).catch(e => {
-      this.onBackgroundError(e)
-      return result.data
+      if (this.returnStale) {
+        this.onBackgroundError(e)
+        return result.data
+      }
+
+      throw e
     })
 
     if (!this.returnStale) {


### PR DESCRIPTION
If the item is out of date but still in cache, there was a problem if you have multiple requests for the same key, they would fail to acquire the lock and then error - it should return the stale data in this case